### PR TITLE
Fix deprecated call for php 5.5

### DIFF
--- a/lib/Diff/Renderer/Html/Array.php
+++ b/lib/Diff/Renderer/Html/Array.php
@@ -176,8 +176,11 @@ class Diff_Renderer_Html_Array extends Diff_Renderer_Abstract
 	{
 		$lines = array_map(array($this, 'ExpandTabs'), $lines);
 		$lines = array_map(array($this, 'HtmlSafe'), $lines);
+		$callback = function($matches) {
+			return $this->fixSpaces($matches[1]);
+		};
 		foreach($lines as &$line) {
-			$line = preg_replace('# ( +)|^ #e', "\$this->fixSpaces('\\1')", $line);
+			$line = preg_replace_callback('# ( +)|^ #', $callback, $line);
 		}
 		return $lines;
 	}


### PR DESCRIPTION
The /e modifier is deprecated in php 5.5 - fix it the right way.
