### PR TITLE
Make `Diff_Renderer_Html_Array::formatLines` method protected

### DIFF
--- a/lib/Diff/Renderer/Html/Array.php
+++ b/lib/Diff/Renderer/Html/Array.php
@@ -172,7 +172,7 @@ class Diff_Renderer_Html_Array extends Diff_Renderer_Abstract
 	 * @param array $lines Array of lines to format.
 	 * @return array Array of the formatted lines.
 	 */
-	private function formatLines($lines)
+	protected function formatLines($lines)
 	{
 		$lines = array_map(array($this, 'ExpandTabs'), $lines);
 		$lines = array_map(array($this, 'HtmlSafe'), $lines);


### PR DESCRIPTION
would be nice to have `Diff_Renderer_Html_Array::formatLines` method `protected` rather than private so classes extending it can use the method (say you create `Diff_Renderer_SideBySide_Html` class)