### PR TITLE
php 5.6 compatible usage of preg_replace_callback

### DIFF
--- a/lib/Diff/Renderer/Html/Array.php
+++ b/lib/Diff/Renderer/Html/Array.php
@@ -177,7 +177,9 @@ class Diff_Renderer_Html_Array extends Diff_Renderer_Abstract
 		$lines = array_map(array($this, 'ExpandTabs'), $lines);
 		$lines = array_map(array($this, 'HtmlSafe'), $lines);
 		foreach($lines as &$line) {
-			$line = preg_replace('# ( +)|^ #e', "\$this->fixSpaces('\\1')", $line);
+			$line = preg_replace_callback('# ( +)|^ #', function ($matches) {
+				return $this->fixSpaces($matches[0]);
+			}, $line);
 		}
 		return $lines;
 	}


### PR DESCRIPTION
avoid messages like "Deprecated: preg_replace(): The /e modifier is deprecated, use preg_replace_callback instead in...." with php 5.6