### PR TITLE
PHP7 Compatibility - remove preg_match with /e modifier

### DIFF
--- a/lib/Diff/Renderer/Html/Array.php
+++ b/lib/Diff/Renderer/Html/Array.php
@@ -177,7 +177,11 @@ class Diff_Renderer_Html_Array extends Diff_Renderer_Abstract
 		$lines = array_map(array($this, 'ExpandTabs'), $lines);
 		$lines = array_map(array($this, 'HtmlSafe'), $lines);
 		foreach($lines as &$line) {
-			$line = preg_replace('# ( +)|^ #e', "\$this->fixSpaces('\\1')", $line);
+			$line = preg_replace_callback('# ( +)|^ #is', 
+				function ($m) {
+                			return $this->fixSpaces($m[1]);
+            			}, 
+            			$line);
 		}
 		return $lines;
 	}


### PR DESCRIPTION
This PR fixes PHP7 compatibility - I doubt anyone will merge it back to the upstream repo as that looks almost abandoned - however here it is for those of you like me that this broke for when they started using PHP7 