### PR TITLE
PHP7 compatibility: Avoid using 'e' modifier in preg_replace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "chrisboulton/php-diff",
-	"type": "library",
+    "type": "library",
     "description": "A comprehensive library for generating differences between two hashable objects (strings or arrays).",
     "authors": [
         {
@@ -8,9 +8,12 @@
             "email": "@chrisboulton"
         }
     ],
-	"autoload": {
-		"psr-0": {
-		   "Diff": "lib/"
-		}
-	}
+    "autoload": {
+        "psr-0": {
+           "Diff": "lib/"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~5.5"
+    }
 }

--- a/lib/Diff/Renderer/Html/Array.php
+++ b/lib/Diff/Renderer/Html/Array.php
@@ -177,7 +177,7 @@ class Diff_Renderer_Html_Array extends Diff_Renderer_Abstract
 		$lines = array_map(array($this, 'ExpandTabs'), $lines);
 		$lines = array_map(array($this, 'HtmlSafe'), $lines);
 		foreach($lines as &$line) {
-			$line = preg_replace('# ( +)|^ #e', "\$this->fixSpaces('\\1')", $line);
+			$line = preg_replace_callback('# ( +)|^ #', array($this, 'fixSpaces'), $line);
 		}
 		return $lines;
 	}
@@ -185,11 +185,12 @@ class Diff_Renderer_Html_Array extends Diff_Renderer_Abstract
 	/**
 	 * Replace a string containing spaces with a HTML representation using &nbsp;.
 	 *
-	 * @param string $spaces The string of spaces.
+	 * @param string[] $matches Array with preg matches.
 	 * @return string The HTML representation of the string.
 	 */
-	function fixSpaces($spaces='')
+	private function fixSpaces(array $matches)
 	{
+		$spaces = $matches[1];
 		$count = strlen($spaces);
 		if($count == 0) {
 			return '';

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Diff/Renderer/Html/ArrayTest.php
+++ b/tests/Diff/Renderer/Html/ArrayTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Diff\Renderer\Html;
+
+class ArrayTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRenderSimpleDelete()
+    {
+        $htmlRenderer = new \Diff_Renderer_Html_Array();
+        $htmlRenderer->diff = new \Diff(
+            array('a'),
+            array()
+        );
+
+        $result = $htmlRenderer->render();
+
+        static::assertEquals(array(
+            array(
+                array(
+                    'tag' => 'delete',
+                    'base' => array(
+                        'offset' => 0,
+                        'lines' => array(
+                            'a'
+                        )
+                    ),
+                    'changed' => array(
+                        'offset' => 0,
+                        'lines' => array()
+                    )
+                )
+            )
+        ), $result);
+    }
+
+    public function testRenderFixesSpaces()
+    {
+        $htmlRenderer = new \Diff_Renderer_Html_Array();
+        $htmlRenderer->diff = new \Diff(
+            array('    a'),
+            array('a')
+        );
+
+        $result = $htmlRenderer->render();
+
+        static::assertEquals(array(
+            array(
+                array(
+                    'tag' => 'replace',
+                    'base' => array(
+                        'offset' => 0,
+                        'lines' => array(
+                            '<del>&nbsp; &nbsp;</del>a',
+                        )
+                    ),
+                    'changed' => array(
+                        'offset' => 0,
+                        'lines' => array(
+                            '<ins></ins>a'
+                        )
+                    )
+                )
+            )
+        ), $result);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
There is already plenty of PRs trying to fix this: https://github.com/chrisboulton/php-diff/pull/32 https://github.com/chrisboulton/php-diff/pull/36, https://github.com/chrisboulton/php-diff/pull/39, and https://github.com/chrisboulton/php-diff/pull/41.

I liked the best solution from https://github.com/chrisboulton/php-diff/pull/41, however I decided to polish it a bit and add test coverage to demostrate that it still works the same.