### PR TITLE
Renderer/Html/Array: Fix Undefined offset for callback fixSpaces

### DIFF
--- a/lib/Diff/Renderer/Html/Array.php
+++ b/lib/Diff/Renderer/Html/Array.php
@@ -190,9 +190,14 @@ class Diff_Renderer_Html_Array extends Diff_Renderer_Abstract
 	 */
 	private function fixSpaces(array $matches)
 	{
-		$spaces = $matches[1];
-		$count = strlen($spaces);
-		if($count == 0) {
+		$count = 0;
+
+		if (count($matches) > 1) {
+			$spaces = $matches[1];
+			$count = strlen($spaces);
+		}
+
+		if ($count == 0) {
 			return '';
 		}
 


### PR DESCRIPTION
It avoids breaking the callback when no spaces are to be counted.

This is a fixup for 2900dd97eb540488c0bc188a0f5b2b6224a41ddd (#42)

/cc @petrkotek