### PR TITLE
Fix multiple space rendering

### DIFF
--- a/lib/Diff/Renderer/Html/Array.php
+++ b/lib/Diff/Renderer/Html/Array.php
@@ -177,7 +177,7 @@ class Diff_Renderer_Html_Array extends Diff_Renderer_Abstract
 		$lines = array_map(array($this, 'ExpandTabs'), $lines);
 		$lines = array_map(array($this, 'HtmlSafe'), $lines);
 		foreach($lines as &$line) {
-			$line = preg_replace_callback('# ( +)|^ #', array($this, 'fixSpaces'), $line);
+			$line = preg_replace_callback('#(  +)|^ #', array($this, 'fixSpaces'), $line);
 		}
 		return $lines;
 	}


### PR DESCRIPTION
The code tries to replace multiple spaces with "nbsp; " and "nbsp;" depending on whether it is odd or even.  The original preg_replace is only capturing the trailing spaces, but replacing all of them, which means the first space always gets silently dropped.