### PR TITLE
Fix fatal error under php 8

### DIFF
--- a/lib/Diff/Renderer/Html/Array.php
+++ b/lib/Diff/Renderer/Html/Array.php
@@ -150,7 +150,7 @@ class Diff_Renderer_Html_Array extends Diff_Renderer_Abstract
 	{
 		$start = 0;
 		$limit = min(strlen($fromLine), strlen($toLine));
-		while($start < $limit && $fromLine{$start} == $toLine{$start}) {
+		while ($start < $limit && $fromLine[$start] == $toLine[$start]) {
 			++$start;
 		}
 		$end = -1;


### PR DESCRIPTION
String offset access with curly braces is no longer allowed in php 8. 
```
     Fatal error: Array and string offset access syntax with curly braces is    
     no longer supported in                                                     
     /home/circleci/project/vendor/chrisboulton/php-diff/lib/Diff/Renderer/Htm  
     l/Array.php on line 153   
```

ping @chrisboulton 